### PR TITLE
Added option to send returned URL to clipboard

### DIFF
--- a/README.org
+++ b/README.org
@@ -68,7 +68,26 @@ Example:
 Can also be put in the =:config= section of =use-package= the same way as the
 provider definitions above.
 
-*** Open recently created pastes in browser
+*** View recently created pastes
+Webpaste gives you several options to view your succesful paste.
+
+**** Send the returned URL to the killring
+This is webpaste's default behavior. After a succesfull paste, the returned URL
+from the provider will be sent to the killring. You can disable this with
+
+#+BEGIN_SRC emacs-lisp
+(setq webpaste/add-to-killring nil)
+#+END_SRC
+
+**** Copy URL to the clipboard
+If you have [[https://github.com/rolandwalker/simpleclip][simpleclip]] installed, you can copy the returned URL to the 
+clipboard. You can enable this with
+
+#+BEGIN_SRC emacs-lisp
+(setq webpaste/copy-to-clipboard t)
+#+END_SRC
+
+**** Open the recently created paste in the browser
 To enable opening of recently created pastes in an external browser, you can
 enable the option =webpaste/open-in-browser= by setting this value to a
 non-nil value.

--- a/webpaste.el
+++ b/webpaste.el
@@ -65,6 +65,14 @@ default to all providers in order defined in ‘webpaste-providers’ list."
 This uses `browse-url-generic' to open URLs."
   :group 'webpaste)
 
+(defcustom webpaste/copy-to-clipboard nil
+  "Uses simpleclip to send the provider's returned URL to the clipboard"
+  :group 'webpaste)
+
+(defcustom webpaste/add-to-killring t
+  "Add the returned URL to the killring after paste"
+  :group 'webpaste)
+
 
 
 (defvar webpaste/tested-providers ()
@@ -393,11 +401,15 @@ return it to the user.")
   (when webpaste/open-in-browser
     (browse-url-generic returned-url))
 
-  ;; Add RETURNED-URL to killring for easy pasting
-  (kill-new returned-url)
+  ;; Send RETURNED-URL to the clipboard using simpleclip
+  (when webpaste/copy-to-clipboard
+    (simpleclip-set-contents returned-url)
+    (message "URL copied to clipboard. "))
 
-  ;; Notify user
-  (message "Added %S to kill ring." returned-url))
+  ;; Add RETURNED-URL to killring for easy pasting
+  (when webpaste/add-to-killring
+    (kill-new returned-url)
+    (message (format "Added %S to kill ring." returned-url))))
 
 
 

--- a/webpaste.el
+++ b/webpaste.el
@@ -409,7 +409,7 @@ return it to the user.")
   ;; Add RETURNED-URL to killring for easy pasting
   (when webpaste/add-to-killring
     (kill-new returned-url)
-    (message (format "Added %S to kill ring." returned-url))))
+    (message "Added %S to kill ring." returned-url)))
 
 
 


### PR DESCRIPTION
If simpleclip is installed, users can send their returned URL to the
clipboard by setting webpaste/copy-to-clipboard to a non-nil value.

This change also adds webpaste/add-to-killring so that sending the URL
to the killring can be disabled, although to keep the same default
behavior the var's value is set to t by default.

The README is also updated to reflect these new options.