### PR TITLE
Fix duplicate elements added to alists

### DIFF
--- a/webpaste.el
+++ b/webpaste.el
@@ -159,6 +159,25 @@ the docs for `webpaste--provider'."
 
 
 
+;; modified from https://emacs.stackexchange.com/a/33893/12534
+(defun webpaste--alist-set (key val alist)
+  "Set property KEY to VAL in ALIST. Return new alist.
+This creates the association if it is missing, and otherwise sets
+the cdr of the first matching association in the list. It does
+not create duplicate associations. Key comparison is done with
+`equal'.
+
+This method may mutate the original alist, but you still need to
+use the return value of this method instead of the original
+alist, to ensure correct results."
+  (let ((pair (assoc key alist)))
+    (if pair
+        (setcdr pair val)
+      (push (cons key val) alist)))
+  alist)
+
+
+
 (defvar webpaste--tested-providers ()
   "Variable for storing which providers to try in which order while running.
 This list will be re-populated each run based on ‘webpaste-provider-priority’ or
@@ -332,11 +351,16 @@ Optional params:
   ;; If we get a separator sent to the function, append it to the list of
   ;; separators for later use
   (when lang-uri-separator
-    (cl-pushnew (cons uri lang-uri-separator) webpaste--provider-separators))
+    (setq webpaste--provider-separators
+          (webpaste--alist-set
+           uri lang-uri-separator webpaste--provider-separators)))
 
   ;; Add pre-calculated list of webpaste lang alists
-  (cl-pushnew (cons uri (webpaste--get-lang-alist-with-overrides lang-overrides))
-              webpaste--provider-lang-alists)
+  (setq webpaste--provider-lang-alists
+        (webpaste--alist-set
+         uri
+         (webpaste--get-lang-alist-with-overrides lang-overrides)
+         webpaste--provider-lang-alists))
 
   (cl-function
    (lambda (text


### PR DESCRIPTION
_Commit message:_ Previously, pasting a buffer multiple times could produce a series of URLs with more and more duplicates of the language specifier appended to the end. Using a dedicated method for mutating alists instead of `cl-pushnew', which introduces duplicates, solves this problem.

We could instead use `map-put` if you are willing to bump the required Emacs version to 25.1.