### PR TITLE
Add toml lang to ptpb.pw default

### DIFF
--- a/webpaste.el
+++ b/webpaste.el
@@ -92,7 +92,8 @@ This uses `browse-url-generic' to open URLs."
      :post-field "c"
      :lang-uri-separator "/"
      :lang-overrides ((emacs-lisp-mode . "elisp")
-                      (nix-mode . "nix"))
+                      (nix-mode . "nix")
+                      (conf-toml-mode . "toml"))
      :success-lambda webpaste--providers-success-location-header)
 
     ("ix.io"


### PR DESCRIPTION
ptpb.pw now supports toml syntax highlighting. Example: https://ptpb.pw/_OSY/toml

The `conf-toml-mode` was introduced in emacs 26.1.

Ref: https://github.com/ptpb/pb/issues/221#issuecomment-411627939