### PR TITLE
Change dpaste.de to dpaste.org.

### DIFF
--- a/README.org
+++ b/README.org
@@ -49,11 +49,11 @@ Examples:
   ;; Choosing githup gist only
   (setq webpaste-provider-priority '("gist.github.com"))
 
-  ;; Choosing ix.io as first provider and dpaste.de as second
-  (setq webpaste-provider-priority '("ix.io" "dpaste.de"))
+  ;; Choosing ix.io as first provider and dpaste.org as second
+  (setq webpaste-provider-priority '("ix.io" "dpaste.org"))
 
-  ;; Choosing 1) ix.io, 2) dpaste.de, 3) dpaste.com
-  (setq webpaste-provider-priority '("ix.io" "dpaste.de" "dpaste.com"))
+  ;; Choosing 1) ix.io, 2) dpaste.org, 3) dpaste.com
+  (setq webpaste-provider-priority '("ix.io" "dpaste.org" "dpaste.com"))
 
   ;; You can always append this list as much as you like, and which providers
   ;; that exists is documented below in the readme.
@@ -67,7 +67,7 @@ This can be added to the =:config= section of use-package:
            ("C-c C-p C-r" . webpaste-paste-region))
     :config
     (progn
-      (setq webpaste-provider-priority '("ix.io" "dpaste.de"))))
+      (setq webpaste-provider-priority '("ix.io" "dpaste.org"))))
 #+END_SRC
 
 ** Only paste plaintext pastes
@@ -178,7 +178,7 @@ webpaste first and then just read the documentation by running this:
  - [ ] 0x0.st
  - [X] ix.io
  - [X] dpaste.com
- - [X] dpaste.de
+ - [X] dpaste.org
  - [X] gist.github.com
  - [X] paste.pound-python.org
  - [ ] paste.debian.net

--- a/tests/integration/test-webpaste-providers.el
+++ b/tests/integration/test-webpaste-providers.el
@@ -37,9 +37,9 @@
 
 
  (it
-  "can paste with dpaste.de [ci]"
+  "can paste with dpaste.org [ci]"
 
-  (funcall (webpaste--get-provider-by-name "dpaste.de") paste-message :sync t)
+  (funcall (webpaste--get-provider-by-name "dpaste.org") paste-message :sync t)
 
   (expect (spy-calls-count 'webpaste--return-url) :to-equal 1)
   (expect (spy-calls-count 'webpaste--paste-text) :to-equal 0))

--- a/webpaste.el
+++ b/webpaste.el
@@ -105,8 +105,8 @@ This uses `browse-url-generic' to open URLs."
      :lang-overrides ((emacs-lisp-mode . "clojure"))
      :success-lambda webpaste--providers-success-location-header)
 
-    ("dpaste.de"
-     :uri "https://dpaste.de/api/"
+    ("dpaste.org"
+     :uri "https://dpaste.org/api/"
      :post-data (("expires" . 86400))
      :post-field "content"
      :post-lang-field-name "lexer"


### PR DESCRIPTION
dpaste.de moved to dpaste.org (see text at the bottom of https://dpaste.org/).

``` shellsession
% curl -Is https://dpaste.de/api/ | grep Location
Location: https://dpaste.org/api/
```

I just replaced all occurences of dpaste.de with dpaste.org.