### PR TITLE
Add wrapper around webpaste for buffer and region

### DIFF
--- a/README.org
+++ b/README.org
@@ -35,7 +35,8 @@ easiest way to install and configure packages.
   (use-package webpaste
     :ensure t
     :bind (("C-c C-p C-b" . webpaste-paste-buffer)
-           ("C-c C-p C-r" . webpaste-paste-region)))
+           ("C-c C-p C-r" . webpaste-paste-region)
+           ("C-c C-p C-p" . webpaste-paste-buffer-or-region)))
 #+END_SRC
 
 * Configuration
@@ -64,7 +65,8 @@ This can be added to the =:config= section of use-package:
   (use-package webpaste
     :ensure t
     :bind (("C-c C-p C-b" . webpaste-paste-buffer)
-           ("C-c C-p C-r" . webpaste-paste-region))
+           ("C-c C-p C-r" . webpaste-paste-region)
+           ("C-c C-p C-p" . webpaste-paste-buffer-or-region))
     :config
     (progn
       (setq webpaste-provider-priority '("ix.io" "dpaste.org"))))

--- a/tests/unit/test-webpaste-paste-region-and-buffer.el
+++ b/tests/unit/test-webpaste-paste-region-and-buffer.el
@@ -81,4 +81,35 @@
             (buffer-substring 10 100)))))
 
 
+(describe
+    "Paste buffer or region, but only choose one at a time depending on context"
+
+  (before-each
+    (spy-on 'webpaste-paste-buffer)
+    (spy-on 'webpaste-paste-region))
+
+  (after-each
+    (deactivate-mark))
+
+  (with-temp-buffer
+    (insert-file-contents "README.org")
+
+    (it "can paste entire buffers"
+      ;; Paste buffer
+      (webpaste-paste-buffer-or-region)
+      (expect 'webpaste-paste-buffer :to-have-been-called-times 1)
+      (expect 'webpaste-paste-region :to-have-been-called-times 0))
+
+    (it "can paste selected region"
+      ;; Mock selection of region
+      (set-mark 10)
+      (goto-char 100)
+      (activate-mark)
+
+      ;; Paste region
+      (webpaste-paste-buffer-or-region)
+      (expect 'webpaste-paste-buffer :to-have-been-called-times 0)
+      (expect 'webpaste-paste-region :to-have-been-called-times 1))))
+
+
 ;;; test-webpaste-paste-region-and-buffer.el ends here

--- a/webpaste.el
+++ b/webpaste.el
@@ -548,6 +548,19 @@ Argument MARK Current mark."
     ;; Extract the buffer contents with buffer-substring and paste it
     (webpaste--paste-text (buffer-substring (point-min) (point-max)))))
 
+
+;;;###autoload
+(cl-defun webpaste-paste-buffer-or-region (&optional point mark)
+  "Paste current buffer or selected region to some paste service"
+  (interactive "r")
+
+  ;; if region is selected
+  (if (region-active-p)
+      ;; Paste selected region
+      (webpaste-paste-region point mark)
+    ;; Else, Paste buffer
+    (webpaste-paste-buffer)))
+
 
 
 (provide 'webpaste)


### PR DESCRIPTION
Added a new function which handles both a region and a whole buffer, depending on if a region is currently selected or not.

I have no idea if this is desirable or not in general, but I found myself implementing this pretty quickly after first trying out this package. One key combination is easier to remember than two I guess.

Even if this gets merged or not, I just want to thank the author for this convenient package. A perfect example of how versatile Emacs really is!

Happy Hacking :keyboard: 