### PR TITLE
Add support for bpa.st pastebin

### DIFF
--- a/README.org
+++ b/README.org
@@ -198,9 +198,9 @@ webpaste first and then just read the documentation by running this:
  - [X] gist.github.com
  - [X] paste.pound-python.org
  - [X] paste.mozilla.org
+ - [X] bpa.st
  - [ ] paste.debian.net
  - [ ] bpaste.net
  - [ ] eval.in
- - [X] bpa.st
  - [ ] ptpb.pw (RIP due to [[https://github.com/ptpb/pb/issues/245][ptpb/pb#245]] & [[https://github.com/ptpb/pb/issues/240][ptpb/pb#240]])
  - [ ] sprunge.us (removed due to [[https://github.com/rupa/sprunge/issues/45][sprunge#45]] that yields 500s)

--- a/README.org
+++ b/README.org
@@ -201,5 +201,6 @@ webpaste first and then just read the documentation by running this:
  - [ ] paste.debian.net
  - [ ] bpaste.net
  - [ ] eval.in
+ - [X] bpa.st
  - [ ] ptpb.pw (RIP due to [[https://github.com/ptpb/pb/issues/245][ptpb/pb#245]] & [[https://github.com/ptpb/pb/issues/240][ptpb/pb#240]])
  - [ ] sprunge.us (removed due to [[https://github.com/rupa/sprunge/issues/45][sprunge#45]] that yields 500s)

--- a/tests/integration/test-webpaste-providers.el
+++ b/tests/integration/test-webpaste-providers.el
@@ -80,7 +80,18 @@
   (funcall (webpaste--get-provider-by-name "paste.pound-python.org") paste-message :sync t)
 
   (expect (spy-calls-count 'webpaste--return-url) :to-equal 1)
-  (expect (spy-calls-count 'webpaste--paste-text) :to-equal 0)))
+  (expect (spy-calls-count 'webpaste--paste-text) :to-equal 0))
+
+
+  (it
+   "can paste with bpa.st [ci]"
+
+   (spy-on 'file-name-nondirectory :and-return-value "file.txt")
+
+   (funcall (webpaste--get-provider-by-name "bpa.st") paste-message :sync t)
+
+   (expect (spy-calls-count 'webpaste--return-url) :to-equal 1)
+   (expect (spy-calls-count 'webpaste--paste-text) :to-equal 0)))
 
 
 ;;; test-webpaste-providers.el ends here

--- a/webpaste.el
+++ b/webpaste.el
@@ -155,7 +155,14 @@ This uses `browse-url-generic' to open URLs."
      :post-field "code"
      :post-lang-field-name "language"
      :lang-overrides ((emacs-lisp-mode . "clojure"))
-     :success-lambda webpaste--providers-success-response-url))
+     :success-lambda webpaste--providers-success-response-url)
+
+    ("bpa.st"
+     :uri "https://bpa.st/api/v1/paste"
+     :post-data (("expiry" . "1day"))
+     :post-field-lambda (lambda () #'webpaste--providers-pinnwand-request)
+     :lang-overrides ((emacs-lisp-mode . "emacs"))
+     :success-lambda (lambda () #'webpaste--providers-pinnwand-success)))
 
   "Define all webpaste.el providers.
 Consists of provider name and arguments to be sent to `webpaste--provider' when
@@ -299,6 +306,22 @@ This is the default failover hook that we use for most providers."
 
                    ;; Otherwise we return the formatted post data
                    post-data))))
+
+(cl-defun webpaste--providers-pinnwand-request (&key text post-data provider-uri
+                                                  &allow-other-keys)
+  "Build request for pinnwand pastebins."
+  (let* ((lexer (or (webpaste--get-buffer-language provider-uri) "text"))
+         (file `(("lexer" . ,lexer) ("content" . ,text)))
+         (file-name (buffer-file-name)))
+    (when file-name
+      (push (cons "name" (file-name-nondirectory file-name)) file))
+    (json-encode `((expiry . ,(or (cdr (assoc "expiry" post-data)) "1day"))
+                   (files . ,(vector file))))))
+
+(cl-defun webpaste--providers-pinnwand-success (&key data &allow-other-keys)
+  "Parse JSON response from pinnwand pastebins in DATA."
+  (webpaste--return-url (cdr (assq 'link (json-read-from-string data)))))
+
 
 
 


### PR DESCRIPTION
bpa.st runs software called pinnwand:
https://pinnwand.readthedocs.io/en/latest/index.html

This uses pinnwand's v1 API.

I added a test, but I can't get it to pass, and I can't get Buttercup to give me any useful debugging information to see why.  Maybe it's obvious to others?  The pasting itself actually works fine in my (limited) local testing.