### PR TITLE
Enable lexical-binding in all test files

### DIFF
--- a/tests/unit/test-webpaste-default-post-field-lambda.el
+++ b/tests/unit/test-webpaste-default-post-field-lambda.el
@@ -1,4 +1,4 @@
-;;; test-webpaste-default-post-field-lambda.el --- Tests for webpaste
+;;; test-webpaste-default-post-field-lambda.el --- Tests for webpaste -*- lexical-binding: t; -*-
 ;;; Commentary:
 ;;; Code:
 

--- a/tests/unit/test-webpaste-error-lambdas.el
+++ b/tests/unit/test-webpaste-error-lambdas.el
@@ -1,4 +1,4 @@
-;;; test-webpaste-error-lambdas.el --- Tests for error lambdas
+;;; test-webpaste-error-lambdas.el --- Tests for error lambdas -*- lexical-binding: t; -*-
 ;;; Commentary:
 ;;; Code:
 

--- a/tests/unit/test-webpaste-get-language.el
+++ b/tests/unit/test-webpaste-get-language.el
@@ -1,4 +1,4 @@
-;;; test-webpaste-get-language.el --- Tests for webpaste
+;;; test-webpaste-get-language.el --- Tests for webpaste -*- lexical-binding: t; -*-
 ;;; Commentary:
 ;;; Code:
 

--- a/tests/unit/test-webpaste-get-provider-priority.el
+++ b/tests/unit/test-webpaste-get-provider-priority.el
@@ -1,4 +1,4 @@
-;;; test-webpaste-get-provider-priority.el --- Tests for webpaste
+;;; test-webpaste-get-provider-priority.el --- Tests for webpaste -*- lexical-binding: t; -*-
 ;;; Commentary:
 ;;; Code:
 

--- a/tests/unit/test-webpaste-paste-region-and-buffer.el
+++ b/tests/unit/test-webpaste-paste-region-and-buffer.el
@@ -1,4 +1,4 @@
-;;; test-webpaste-paste-region-and-buffer.el --- Tests for webpaste
+;;; test-webpaste-paste-region-and-buffer.el --- Tests for webpaste -*- lexical-binding: t; -*-
 ;;; Commentary:
 ;;; Code:
 

--- a/tests/unit/test-webpaste-paste-text.el
+++ b/tests/unit/test-webpaste-paste-text.el
@@ -1,4 +1,4 @@
-;;; test-webpaste-paste-text.el --- Tests for webpaste
+;;; test-webpaste-paste-text.el --- Tests for webpaste -*- lexical-binding: t; -*-
 ;;; Commentary:
 ;;; Code:
 

--- a/tests/unit/test-webpaste-provider-creation.el
+++ b/tests/unit/test-webpaste-provider-creation.el
@@ -1,4 +1,4 @@
-;;; test-webpaste-provider-creation.el --- Tests for webpaste
+;;; test-webpaste-provider-creation.el --- Tests for webpaste -*- lexical-binding: t; -*-
 ;;; Commentary:
 ;;; Code:
 

--- a/tests/unit/test-webpaste-return-url.el
+++ b/tests/unit/test-webpaste-return-url.el
@@ -1,4 +1,4 @@
-;;; test-webpaste-return-url.el --- Tests for webpaste
+;;; test-webpaste-return-url.el --- Tests for webpaste -*- lexical-binding: t; -*-
 ;;; Commentary:
 ;;; Code:
 

--- a/tests/unit/test-webpaste-success-lambdas.el
+++ b/tests/unit/test-webpaste-success-lambdas.el
@@ -1,4 +1,4 @@
-;;; test-webpaste-success-lambdas.el --- Tests for success lambdas
+;;; test-webpaste-success-lambdas.el --- Tests for success lambdas -*- lexical-binding: t; -*-
 ;;; Commentary:
 ;;; Code:
 

--- a/tests/unit/test-webpaste.el
+++ b/tests/unit/test-webpaste.el
@@ -1,4 +1,4 @@
-;;; test-webpaste.el --- Tests for webpaste
+;;; test-webpaste.el --- Tests for webpaste -*- lexical-binding: t; -*-
 ;;; Commentary:
 ;;; Code:
 


### PR DESCRIPTION
This is required by buttercup, and a hard error with buttercup >= 1.34 and Emacs >= 29.1.

Reported by @xgqt in https://github.com/jorgenschaefer/emacs-buttercup/issues/243