### PR TITLE
Fix wide docstring warnings

### DIFF
--- a/webpaste.el
+++ b/webpaste.el
@@ -382,33 +382,35 @@ Optional params:
                         use to the provider.
 
 :lang-overrides    Alist defining overrides for languages for this provider.  If
-                   a mode is set to nil, it will use fundamental-mode's value as
-                   fallback.  Fundamental-mode's value can also be overridden.
+                   a mode is set to nil, it will use fundamental-mode\\='s
+                   value as fallback.  Fundamental-mode\\='s value can also be
+                   overridden.
 
 :lang-uri-separator   Lang URI separator.  This is used for providers that
                       appends the language to the end of the resulting URI and
                       needs a separator between language and link.
 
-:parser            Defines how request.el parses the result.  Look up :parser for
-                   `request'.  This defaults to 'buffer-string.
+:parser            Defines how request.el parses the result.  Look up :parser
+                   for `request'.  This defaults to \\='buffer-string.
 
 :error-lambda      Callback sent to `request', look up how to write these in the
                    documentation for `request'.  The default value for this is
-                   `webpaste--providers-error-lambda', but there's also
+                   `webpaste--providers-error-lambda', but there\\='s also
                    `webpaste--providers-error-lambda-no-failover' available if
-                   you need a provider that isn't allowed to failover.
+                   you need a provider that isn\\='t allowed to failover.
 
 :post-field-lambda Function that builds and returns the post data that should be
                    sent to the provider.  It should accept named parameters by
                    the names TEXT, POST-FIELD and POST-DATA.  POST-DATA should
-                   default to 'nil' or empty list.  It also takes the option
+                   default to `nil' or empty list.  It also takes the option
                    LANG-OVERRIDES which is a list that enables overriding of
                    `webpaste--default-lang-alist'.
 
                    TEXT contains the data that should be sent.
                    POST-FIELD contains the name of the field to be sent.
                    POST-DATA contains predefined fields that the provider needs.
-                   SUCCESS-LAMBDA contains the function to run on an successful paste."
+                   SUCCESS-LAMBDA contains the function to run on an successful
+                   paste."
   ;; If we get a separator sent to the function, append it to the list of
   ;; separators for later use
   (when lang-uri-separator
@@ -473,8 +475,8 @@ Optional params:
 
 Return nil if no shebang found.
 
-Example: For \"#!/usr/bin/env bash\", 'bash-mode is returned.
-         For \"#!/bin/python\", 'python-mode is returned."
+Example: For \"#!/usr/bin/env bash\", \\='bash-mode is returned.
+         For \"#!/bin/python\", \\='python-mode is returned."
 
   (let* ((end-of-first-line (save-excursion
                               (save-restriction


### PR DESCRIPTION
Fixes the following warnings in `webpaste--provider` and `webpaste--get-shebang-lang-mode`:

```
Warning (comp): webpaste.el:347:2: Warning: docstring wider than 80 characters
Warning (comp): webpaste.el:347:2: Warning: docstring has wrong usage of unescaped single quotes (use \= or different quoting)
```

See [Section 25.3 *Substituting Key Bindings in Documentation*](https://www.gnu.org/software/emacs/manual/html_mono/elisp.html#Keys-in-Documentation) of the Emacs Lisp manual.