### PR TITLE
Fix emacs-lisp language override for bpa.st

### DIFF
--- a/webpaste.el
+++ b/webpaste.el
@@ -162,7 +162,7 @@ This uses `browse-url-generic' to open URLs."
      :uri "https://bpa.st/api/v1/paste"
      :post-data (("expiry" . "1day"))
      :post-field-lambda webpaste--providers-pinnwand-request
-     :lang-overrides ((emacs-lisp-mode . "emacs"))
+     :lang-overrides ((emacs-lisp-mode . "emacs-lisp"))
      :success-lambda webpaste--providers-pinnwand-success))
 
   "Define all webpaste.el providers.


### PR DESCRIPTION
According to the [pinnwand docs](https://pinnwand.readthedocs.io/en/latest/usage.html#json-lexers), you can get the valid lexers by making a request to:

```sh
http://<INSTANCE>/api/v1/lexer
# Or
http://<INSTANCE>/json/lexers

```

This JSON reply currently contains:

```
'emacs-lisp': 'EmacsLisp'
``` 

I am guessing this used to be:

```
'emacs': 'EmacsLisp'
``` 