### PR TITLE
Remove arguments from `webpaste-paste-buffer-or-region`

### DIFF
--- a/webpaste.el
+++ b/webpaste.el
@@ -618,15 +618,14 @@ Argument MARK Current mark."
 
 
 ;;;###autoload
-(cl-defun webpaste-paste-buffer-or-region (&optional point mark)
-  "Paste current buffer or selected region to some paste service.
-Takes optional POINT and MARK to paste a region."
-  (interactive "r")
+(cl-defun webpaste-paste-buffer-or-region ()
+  "Paste current buffer or selected region to some paste service."
+  (interactive)
 
   ;; if region is selected
   (if (region-active-p)
       ;; Paste selected region
-      (webpaste-paste-region point mark)
+      (webpaste-paste-region (region-beginning) (region-end))
     ;; Else, Paste buffer
     (webpaste-paste-buffer)))
 


### PR DESCRIPTION
Using `(interactive "r")` produces the following error message right after starting Emacs (or after creating new buffers, perhaps?):

```
execute-extended-command: The mark is not set now, so there is no region
```

Since this commit changes the function arguments, it might break some existing calls from Elisp, so the change might not be worth it.

I decided to separate this PR from #61, since they are not related.